### PR TITLE
Update main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ redis_bind: '127.0.0.1'
 redis_pidfile: '/var/run/redis/{{ redis_service_name }}.pid'
 redis_logfile: '/var/log/redis/{{ redis_service_name }}.log'
 redis_loglevel: 'notice'
-redis_tcp_backlog: '511'
+redis_tcp_backlog: 511
 redis_unixsocket: false
 redis_timeout: '0'
 redis_tcp_keepalive: '0'


### PR DESCRIPTION
fixed the following error message:
```
fatal: [192.168.10.42]: FAILED! => {"msg": "The conditional check '{{ sysctl_somaxconn.stdout|int < redis_tcp_backlog }}' failed. The error was: Unexpected templating type error occurred on ({{ sysctl_somaxconn.stdout|int < redis_tcp_backlog }}): '<' not supported between instances of 'int' and 'AnsibleUnicode'\n\nThe error appears to have been in '/Users/jumping.qu/Documents/datahub/terraform/plays/datahub/playbooks/roles/redis/tasks/configure.yml': line 7, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: 'Redis | Override system somaxconn setting.'\n  ^ here\n"}
```